### PR TITLE
Added new margins and less width to Map

### DIFF
--- a/src/components/Map/SharedMap.js
+++ b/src/components/Map/SharedMap.js
@@ -34,7 +34,7 @@ class SharedMap extends Component {
       />
     )
     return (
-      <div style={{ marginTop:20, paddingRight: 20, height: '700px', width: '100%', position: "relative" }}>
+      <div style={{ marginTop:20, padding: "10px 20px 0px 20px", height: '600px', width: '100%', maxWidth: "980px", position: "relative" }}>
         <SearchBox style={{zIndex: 100, fontSize: "1.2rem", height: 40, width: 260, position: "absolute", top: 20, left: 20}} onPlacesChanged={this.changeCurrentPlace}/>
         <GoogleMap
           bootstrapURLKeys={{


### PR DESCRIPTION
Now form will not overlap the map in a normal 1920px display. Attached image, tell me if you want more top or left/right margin.

![localhost_3000_map](https://user-images.githubusercontent.com/11179847/45083104-335fdb00-b0fb-11e8-9013-fd2aa50921ad.png)

