### PR TITLE
Remove drizzle message while connecting. 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6206,6 +6206,15 @@
         }
       }
     },
+    "ethereum-blockies-png": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ethereum-blockies-png/-/ethereum-blockies-png-0.1.3.tgz",
+      "integrity": "sha512-w20so1bo2dsCbfozOvkHBycS66OeI59buiBAwN+5ri6fdWIdNl1jKdKcYReizrp8NmidnlQZe04Gua5FUBm8wg==",
+      "requires": {
+        "parse-color": "^1.0.0",
+        "pngjs": "^3.2.0"
+      }
+    },
     "ethereum-common": {
       "version": "0.0.18",
       "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
@@ -15921,6 +15930,21 @@
         "pbkdf2": "^3.0.3"
       }
     },
+    "parse-color": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-color/-/parse-color-1.0.0.tgz",
+      "integrity": "sha1-e3SLlag/A/FqlPU15S1/PZRlhhk=",
+      "requires": {
+        "color-convert": "~0.5.0"
+      },
+      "dependencies": {
+        "color-convert": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+          "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0="
+        }
+      }
+    },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
@@ -16427,6 +16451,11 @@
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
+    },
+    "pngjs": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.3.3.tgz",
+      "integrity": "sha512-1n3Z4p3IOxArEs1VRXnZ/RXdfEniAUS9jb68g58FIXMNkPJeZd+Qh4Uq7/e0LVxAQGos1eIUrqrt4FpjdnEd+Q=="
     },
     "podium": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "chart.js": "^2.7.2",
     "drizzle": "^1.2.3",
     "drizzle-react": "^1.2.0",
+    "ethereum-blockies-png": "^0.1.3",
     "faker": "^4.1.0",
     "google-map-react": "^1.0.6",
     "ipfs-api": "^24.0.1",

--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,7 @@ import { publicRoutes, privateRoutes } from "./routes";
 import { connect } from "react-redux";
 import { UserActions } from "./redux/UserActions";
 
+import Logout from "./components/Logout";
 import PublicLayout from "./layouts/PublicLayout";
 import PrivateLayout from "./layouts/PrivateLayout";
 
@@ -65,6 +66,7 @@ class App extends Component {
             />
           );
         })}
+        <Route path="/logout" component={Logout} />
         <Route component={Error404} />
       </Switch>
     );

--- a/src/components/Consumer/Consumer.js
+++ b/src/components/Consumer/Consumer.js
@@ -25,7 +25,7 @@ import nuclearOnIcon from "../../static//nuclear-energy-60x60-on.png";
 
 import "./Consumer.css";
 import ipfs from "../../ipfs";
-import withDrizzleContext from "../../utils/withDrizzleContext";
+import withRawDrizzle from "../../utils/withRawDrizzle";
 import { connect } from "react-redux";
 import { countryOptions } from "./common";
 import MyStep from "./stepper/MyStep";
@@ -601,4 +601,4 @@ function mapStateToProps(state, props) {
   return { user: state.userReducer };
 }
 
-export default withDrizzleContext(connect(mapStateToProps)(Consumer));
+export default withRawDrizzle(connect(mapStateToProps)(Consumer));

--- a/src/components/Finance/Finance.js
+++ b/src/components/Finance/Finance.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from "react";
 import { Feed, Sidebar, Responsive, Segment, Grid } from "semantic-ui-react";
 import MainChart from "./MainChart";
-import withDrizzleContext from "../../utils/withDrizzleContext.js";
+import withRawDrizzle from "../../utils/withRawDrizzle.js";
 import { Line, Pie } from "react-chartjs-2";
 import "./Finance.less";
 import styled from "styled-components";
@@ -237,4 +237,4 @@ class Finance extends Component {
   }
 }
 
-export default withDrizzleContext(Finance);
+export default withRawDrizzle(Finance);

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import withDrizzleContext from "../../utils/withDrizzleContext";
+import withRawDrizzle from "../../utils/withRawDrizzle";
 import ipfs from "../../ipfs";
 import { Feed, Grid } from "semantic-ui-react";
 import _ from "lodash";
@@ -246,4 +246,4 @@ function mapStateToProps(state, props) {
   return { user: state.userReducer };
 }
 
-export default withDrizzleContext(connect(mapStateToProps)(Home));
+export default withRawDrizzle(connect(mapStateToProps)(Home));

--- a/src/components/Producer/Producer.js
+++ b/src/components/Producer/Producer.js
@@ -10,7 +10,7 @@ import {
   Table
 } from "semantic-ui-react";
 import SharedMap from "./SharedMap";
-import withDrizzleContext from "../../utils/withDrizzleContext";
+import withRawDrizzle from "../../utils/withRawDrizzle";
 import { connect } from "react-redux";
 import _ from "lodash";
 import "./Producer.less";
@@ -508,4 +508,4 @@ function mapStateToProps(state, props) {
   return { user: state.userReducer };
 }
 
-export default withDrizzleContext(connect(mapStateToProps)(Producer));
+export default withRawDrizzle(connect(mapStateToProps)(Producer));

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import { Button, Form, Message } from "semantic-ui-react";
 import { CountryDropdown, RegionDropdown } from "react-country-region-selector";
-import withDrizzleContext from "../../utils/withDrizzleContext";
+import withRawDrizzle from "../../utils/withRawDrizzle";
 import { connect } from "react-redux";
 import ipfs from "../../ipfs";
 import _ from "lodash";
@@ -181,4 +181,4 @@ function mapStateToProps(state, props) {
   return { user: state.userReducer };
 }
 
-export default withDrizzleContext(connect(mapStateToProps)(Settings));
+export default withRawDrizzle(connect(mapStateToProps)(Settings));

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,6 +1,5 @@
 import SignIn from "./components/SignIn/SignIn";
 import SignUp from "./components/SignUp/SignUp";
-import Logout from "./components/Logout";
 import Forgot from "./components/SignIn/Forgot";
 import DashboardHome from "./components/Home/Home";
 import Consumer from "./components/Consumer/Consumer";
@@ -83,10 +82,5 @@ export const privateRoutes = {
     iconOff: settingsIconOff,
     iconOn: settingsIconOn
   },
-  Logout: {
-    path: "/logout",
-    component: Logout,
-    title: "Logout",
-    hiddenOnSideBar: true
-  }
+  
 };


### PR DESCRIPTION
- Remove drizzle message "Connecting to ethereum..." in white page prior connection to the dashboard.
- Now it shows a centered loading icon, until the Web3 provider is connected.
- If Drizzle detects a Web3 provider, but the account is locked, for example when you are not signed in Metamask, the app will logout the current user and redirect to the public main page.
- Minor changes to components that depends from drizzle state.